### PR TITLE
Rename compatibilityRules to compatibilityDependencyRules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 ## How to use
 
 Add to your `project/plugins.sbt`:
+
 ```scala
 addSbtPlugin("ch.epfl.scala" % "sbt-compatibility" % "0.0.9")
 ```
+
 The latest version is [![Maven Central](https://img.shields.io/maven-central/v/ch.epfl.scala/sbt-compatibility-dummy_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/ch.epfl.scala/sbt-compatibility-dummy_2.12).
 
 sbt-compatibility depends on [sbt-mima](https://github.com/lightbend/mima), so that you don't need to explicitly
@@ -45,11 +47,12 @@ The previously compatible version is computed from `version` the following way:
 
 By default, `compatibilityPreviousArtifacts` relies on `mimaPreviousArtifacts` from sbt-mima, so that only setting / changing `mimaPreviousArtifacts` is enough for both sbt-mima and sbt-compatibility.
 
-## `compatibilityRules`
+## Dependency compatibility adjustments
 
-`compatibilityRules` allows to specify whether some version bumps are allowed or not, like
+Set `dependencyCompatibilityRules` to specify whether library dependency upgrades are compatible or not. For instance:
+
 ```scala
-compatibilityRules += "org.scala-lang.modules" %% "scala-xml" % "semver"
+dependencyCompatibilityRules += "org.scala-lang" % "scala-compiler" % "strict"
 ```
 
 The following compatility types are available:
@@ -58,8 +61,8 @@ The following compatility types are available:
 - `always`: assumes all versions of the matched modules are compatible with each other,
 - `strict`: requires exact matches between the wanted and the selected versions of the matched modules.
 
-If no rule for a module is found in `compatibilityRules`, `compatibilityDefaultReconciliation` is used
-as a compatibility type. It's default value is `VersionCompatibility.PackVer` (package versioning policy).
+If no rule for a module is found in `dependencyCompatibilityRules`, `compatibilityDefaultReconciliation` is used
+as a compatibility type. Its default value is `VersionCompatibility.PackVer` (package versioning policy).
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ By default, `compatibilityPreviousArtifacts` relies on `mimaPreviousArtifacts` f
 
 ## Dependency compatibility adjustments
 
-Set `dependencyCompatibilityRules` to specify whether library dependency upgrades are compatible or not. For instance:
+Set `compatibilityDependencyRules` to specify whether library dependency upgrades are compatible or not. For instance:
 
 ```scala
-dependencyCompatibilityRules += "org.scala-lang" % "scala-compiler" % "strict"
+compatibilityDependencyRules += "org.scala-lang" % "scala-compiler" % "strict"
 ```
 
 The following compatility types are available:
@@ -61,7 +61,7 @@ The following compatility types are available:
 - `always`: assumes all versions of the matched modules are compatible with each other,
 - `strict`: requires exact matches between the wanted and the selected versions of the matched modules.
 
-If no rule for a module is found in `dependencyCompatibilityRules`, `compatibilityDefaultReconciliation` is used
+If no rule for a module is found in `compatibilityDependencyRules`, `compatibilityDefaultReconciliation` is used
 as a compatibility type. Its default value is `VersionCompatibility.PackVer` (package versioning policy).
 
 ## Acknowledgments

--- a/build.sbt
+++ b/build.sbt
@@ -13,16 +13,20 @@ inThisBuild(List(
   )
 ))
 
-lazy val `sbt-compatibility-rules` = project
+lazy val root = (project in file("."))
+  .aggregate(`sbt-compatibility-rules`, `sbt-compatibility`)
   .settings(
-    sbtPlugin := true
+    name := "sbt compatiblity root",
+    publish / skip := true,
   )
+
+lazy val `sbt-compatibility-rules` = project
+  .enablePlugins(SbtPlugin)
 
 lazy val `sbt-compatibility` = project
   .dependsOn(`sbt-compatibility-rules`)
-  .enablePlugins(ScriptedPlugin)
+  .enablePlugins(SbtPlugin)
   .settings(
-    sbtPlugin := true,
     scriptedLaunchOpts += "-Dplugin.version=" + version.value,
     scriptedBufferLog := false,
     addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.7.0"),

--- a/sbt-compatibility-rules/src/main/scala/sbtcompatibilityrules/SbtCompatibilityRulesPlugin.scala
+++ b/sbt-compatibility-rules/src/main/scala/sbtcompatibilityrules/SbtCompatibilityRulesPlugin.scala
@@ -7,11 +7,11 @@ object SbtCompatibilityRulesPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   object autoImport {
-    val dependencyCompatibilityRules = taskKey[Seq[ModuleID]]("""Compatibility rules for the library dependencies (e.g. "org.scala-lang" % "scala-compiler" % "strict")""")
+    val compatibilityDependencyRules = taskKey[Seq[ModuleID]]("""Compatibility rules for the library dependencies (e.g. "org.scala-lang" % "scala-compiler" % "strict")""")
   }
   import autoImport._
 
   override def globalSettings = Def.settings(
-    dependencyCompatibilityRules := Seq.empty
+    compatibilityDependencyRules := Seq.empty
   )
 }

--- a/sbt-compatibility-rules/src/main/scala/sbtcompatibilityrules/SbtCompatibilityRulesPlugin.scala
+++ b/sbt-compatibility-rules/src/main/scala/sbtcompatibilityrules/SbtCompatibilityRulesPlugin.scala
@@ -7,11 +7,11 @@ object SbtCompatibilityRulesPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   object autoImport {
-    val compatibilityRules = taskKey[Seq[ModuleID]]("")
+    val dependencyCompatibilityRules = taskKey[Seq[ModuleID]]("""Compatibility rules for the library dependencies (e.g. "org.scala-lang" % "scala-compiler" % "strict")""")
   }
   import autoImport._
 
-  override def buildSettings = Def.settings(
-    compatibilityRules := Seq.empty
+  override def globalSettings = Def.settings(
+    dependencyCompatibilityRules := Seq.empty
   )
 }

--- a/sbt-compatibility/src/main/scala/sbtcompatibility/SbtCompatibilityKeys.scala
+++ b/sbt-compatibility/src/main/scala/sbtcompatibility/SbtCompatibilityKeys.scala
@@ -11,8 +11,6 @@ trait SbtCompatibilityKeys {
   final val compatibilityCheck                  = taskKey[Unit]("Runs both compatibilityReportDependencyIssues and mimaReportBinaryIssues")
   final val forwardCompatibilityCheck           = taskKey[Unit]("")
 
-  @deprecated("Use compatibilityRules instead", "0.0.8")
-  final def compatibilityReconciliations         = SbtCompatibilityRulesPlugin.autoImport.compatibilityRules
   final val compatibilityIgnored                 = taskKey[Seq[OrganizationArtifactName]]("")
   final val compatibilityCheckDirection          = taskKey[Direction]("")
 

--- a/sbt-compatibility/src/main/scala/sbtcompatibility/SbtCompatibilitySettings.scala
+++ b/sbt-compatibility/src/main/scala/sbtcompatibility/SbtCompatibilitySettings.scala
@@ -9,6 +9,7 @@ import lmcoursier.CoursierDependencyResolution
 import lmcoursier.definitions.Reconciliation
 import sbtcompatibility.internal.{DependencyCheck, MimaIssues}
 import sbtcompatibilityrules.SbtCompatibilityRulesPlugin
+import SbtCompatibilityRulesPlugin.autoImport.dependencyCompatibilityRules
 
 import scala.util.Try
 
@@ -78,7 +79,7 @@ object SbtCompatibilitySettings {
     compatibilityDetailedReconciliations := {
       val sv = scalaVersion.value
       val sbv = scalaBinaryVersion.value
-      SbtCompatibilityRulesPlugin.autoImport.compatibilityRules.value.map { mod =>
+      dependencyCompatibilityRules.value.map { mod =>
         val rec = VersionCompatibility(mod.revision) match {
           case Some(r) => r
           case None => sys.error(s"Unrecognized reconciliation '${mod.revision}' in $mod")

--- a/sbt-compatibility/src/main/scala/sbtcompatibility/SbtCompatibilitySettings.scala
+++ b/sbt-compatibility/src/main/scala/sbtcompatibility/SbtCompatibilitySettings.scala
@@ -9,7 +9,7 @@ import lmcoursier.CoursierDependencyResolution
 import lmcoursier.definitions.Reconciliation
 import sbtcompatibility.internal.{DependencyCheck, MimaIssues}
 import sbtcompatibilityrules.SbtCompatibilityRulesPlugin
-import SbtCompatibilityRulesPlugin.autoImport.dependencyCompatibilityRules
+import SbtCompatibilityRulesPlugin.autoImport.compatibilityDependencyRules
 
 import scala.util.Try
 
@@ -79,7 +79,7 @@ object SbtCompatibilitySettings {
     compatibilityDetailedReconciliations := {
       val sv = scalaVersion.value
       val sbv = scalaBinaryVersion.value
-      dependencyCompatibilityRules.value.map { mod =>
+      compatibilityDependencyRules.value.map { mod =>
         val rec = VersionCompatibility(mod.revision) match {
           case Some(r) => r
           case None => sys.error(s"Unrecognized reconciliation '${mod.revision}' in $mod")

--- a/sbt-compatibility/src/sbt-test/sbt-compatibility/defaults/build.sbt
+++ b/sbt-compatibility/src/sbt-test/sbt-compatibility/defaults/build.sbt
@@ -38,7 +38,7 @@ lazy val bumpScalaAndAddRule = project
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.4"
     ),
     version := "0.1.1",
-    compatibilityRules += "org.scala-lang.modules" %% "*" % "semver"
+    dependencyCompatibilityRules += "org.scala-lang.modules" %% "*" % "semver"
   )
 
 inThisBuild(List(

--- a/sbt-compatibility/src/sbt-test/sbt-compatibility/defaults/build.sbt
+++ b/sbt-compatibility/src/sbt-test/sbt-compatibility/defaults/build.sbt
@@ -38,7 +38,7 @@ lazy val bumpScalaAndAddRule = project
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.4"
     ),
     version := "0.1.1",
-    dependencyCompatibilityRules += "org.scala-lang.modules" %% "*" % "semver"
+    compatibilityDependencyRules += "org.scala-lang.modules" %% "*" % "semver"
   )
 
 inThisBuild(List(

--- a/sbt-compatibility/src/sbt-test/sbt-compatibility/in-this-build/build.sbt
+++ b/sbt-compatibility/src/sbt-test/sbt-compatibility/in-this-build/build.sbt
@@ -19,6 +19,6 @@ lazy val b = project
 inThisBuild(List(
   scalaVersion := "2.12.11",
   organization := "io.github.alexarchambault.sbtcompatibility.test2",
-  compatibilityRules += "org.scala-lang.modules" %% "scala-xml" % "semver"
+  dependencyCompatibilityRules += "org.scala-lang.modules" %% "scala-xml" % "semver"
 ))
 

--- a/sbt-compatibility/src/sbt-test/sbt-compatibility/in-this-build/build.sbt
+++ b/sbt-compatibility/src/sbt-test/sbt-compatibility/in-this-build/build.sbt
@@ -19,6 +19,6 @@ lazy val b = project
 inThisBuild(List(
   scalaVersion := "2.12.11",
   organization := "io.github.alexarchambault.sbtcompatibility.test2",
-  dependencyCompatibilityRules += "org.scala-lang.modules" %% "scala-xml" % "semver"
+  compatibilityDependencyRules += "org.scala-lang.modules" %% "scala-xml" % "semver"
 ))
 

--- a/sbt-compatibility/src/sbt-test/sbt-compatibility/simple/build.sbt
+++ b/sbt-compatibility/src/sbt-test/sbt-compatibility/simple/build.sbt
@@ -85,7 +85,7 @@ lazy val f = project
     libraryDependencies ++= Seq(
       "com.chuusai" %% "shapeless" % "2.3.3"
     ),
-    dependencyCompatibilityRules += "com.chuusai" %% "shapeless" % "strict",
+    compatibilityDependencyRules += "com.chuusai" %% "shapeless" % "strict",
     version := "0.1.1"
   )
 
@@ -96,7 +96,7 @@ lazy val g = project
     libraryDependencies ++= Seq(
       "com.chuusai" %% "shapeless" % "2.3.3"
     ),
-    dependencyCompatibilityRules += "com.chuusai" %% "shapeless" % "pvp",
+    compatibilityDependencyRules += "com.chuusai" %% "shapeless" % "pvp",
     version := "0.1.1"
   )
 

--- a/sbt-compatibility/src/sbt-test/sbt-compatibility/simple/build.sbt
+++ b/sbt-compatibility/src/sbt-test/sbt-compatibility/simple/build.sbt
@@ -85,7 +85,7 @@ lazy val f = project
     libraryDependencies ++= Seq(
       "com.chuusai" %% "shapeless" % "2.3.3"
     ),
-    compatibilityRules += "com.chuusai" %% "shapeless" % "strict",
+    dependencyCompatibilityRules += "com.chuusai" %% "shapeless" % "strict",
     version := "0.1.1"
   )
 
@@ -96,7 +96,7 @@ lazy val g = project
     libraryDependencies ++= Seq(
       "com.chuusai" %% "shapeless" % "2.3.3"
     ),
-    compatibilityRules += "com.chuusai" %% "shapeless" % "pvp",
+    dependencyCompatibilityRules += "com.chuusai" %% "shapeless" % "pvp",
     version := "0.1.1"
   )
 


### PR DESCRIPTION
The currently called `compatibilityRules` is about compatibility about the library dependencies, similar to `dependencyOverrides`. Usually I'd recommend naming keys based on the plugin name, but in this case I think it would be clearer if this is named `dependencyCompatibilityRules`.
